### PR TITLE
add settings for Pokemon Snap

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -299,6 +299,10 @@ frameBufferEmulation\copyDepthToRDRAM=1
 Good_Name=Pokemon Puzzle League (E)(F)(G)(U)
 frameBufferEmulation\detectCFB=1
 
+[POKEMON%20SNAP]
+Good_Name=Pokemon Snap (U)
+frameBufferEmulation\copyToRDRAM=1
+
 [POKEMON%20STADIUM%202]
 Good_Name=Pokemon Stadium 2 (E)(F)(G)(I)(J)(S)(U)
 frameBufferEmulation\copyToRDRAM=0

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -337,7 +337,8 @@ void RSP_Init()
 	else if (strstr(RSP.romname, (const char *)"QUAKE II") != NULL ||
 		strstr(RSP.romname, (const char *)"Quake") != NULL ||
 		strstr(RSP.romname, (const char *)"Perfect Dark") ||
-		strstr(RSP.romname, (const char *)"PERFECT DARK")
+		strstr(RSP.romname, (const char *)"PERFECT DARK") ||
+		strstr(RSP.romname, (const char *)"POKEMON SNAP")
 		)
 		config.generalEmulation.hacks |= hack_VIUpdateOnCIChange;
 	else if (strstr(RSP.romname, (const char *)"MASK") != NULL) // Zelda MM


### PR DESCRIPTION
hack_VIUpdateOnCIChange to fix depth problems and flickering
copyToRDRAM=1 (fb sync) for correct pictures
